### PR TITLE
Allow getting toc by evaluating expressions

### DIFF
--- a/README
+++ b/README
@@ -10,6 +10,12 @@ variables or in global filetype-specific (g:ttoc_rx_{&filetype})
 variables. The order actually is: [wbg]:ttoc_rx_{&filetype} > 
 [wbg]:ttoc_rx.
 
+The TToC command can also evaluate an expression to get the line numbers. The
+expression is evalutated if TToC is invoked without a regex argument and the
+expression is defined for that filetype (g:ttoc_expr_{&filetype}). The
+expression needs to return either a sorted and unique list of line numbers
+either as a vim list or as a newline-separated string.
+
 In the list view, you can select a line and either preview it (<c-p>), 
 jump there (<), close the list and jump there (<cr>).
 

--- a/doc/ttoc.txt
+++ b/doc/ttoc.txt
@@ -13,6 +13,12 @@ variables or in global filetype-specific (g:ttoc_rx_{&filetype})
 variables. The order actually is: [wbg]:ttoc_rx_{&filetype} > 
 [wbg]:ttoc_rx.
 
+The TToC command can also evaluate an expression to get the line numbers. The
+expression is evalutated if TToC is invoked without a regex argument and the
+expression is defined for that filetype (g:ttoc_expr_{&filetype}). The
+expression needs to return either a sorted and unique list of line numbers
+either as a vim list or as a newline-separated string.
+
 In the list view, you can select a line and either preview it (<c-p>), 
 jump there (<), close the list and jump there (<cr>).
 


### PR DESCRIPTION
The expression is file-specific(`g:ttoc_expr_{&filetype}`) and should
return the list of line nubmers either as a vim list or as a
newline-separated string. The list needs to be sorted and unique.

Example - use `etags` to get the line numbers from etags:

``` vim
let g:ttoc_expr_c = 'system("etags --parse-stdin=c --output - --no-members | sed \"s/.*([0-9]+),[0-9]+$/\\1/p\" -rn", getline(1, "$"))'
```

I gave an example with C because everyone knows C, but I actually want this for [D](http://dlang.org/), where the declaration syntax is more complex than C and while I _can_ probably write a regex if I try hard enough, I prefer to use tools like [dscanner](https://github.com/Hackerpilot/Dscanner) to locate the declarations for me. I assume it can come even more handy in languages like lisps where the declaration syntax is much more fluid...
